### PR TITLE
Display key values in open key notation by default

### DIFF
--- a/Screens/Views/Browser/ListDelegate.qml
+++ b/Screens/Views/Browser/ListDelegate.qml
@@ -23,8 +23,8 @@ Item {
   readonly property int  textTopMargin:         7 // centers text vertically
   readonly property bool isLoaded:              (model.dataType == BrowserDataType.Track) ? model.loadedInDeck.length > 0 : false
   // visible: !ListView.isCurrentItem
-  readonly property variant keyText:            ["8B", "3B", "10B", "5B", "12B", "7B", "2B", "9B", "4B", "11B", "6B", "1B",
-                                                 "5A", "12A", "7A", "2A", "9A", "4A", "11A", "6A", "1A", "8A", "3A", "10A"]
+  readonly property variant keyText:            ["1d", "8d", "3d", "10d", "5d", "12d", "7d", "2d", "9d", "4d", "11d", "6d",
+                                                 "10m", "5m", "12m", "7m", "2m", "9m", "4m", "11m", "6m", "1m", "8m", "3m"]
 
   height: 33
   anchors.left: parent.left


### PR DESCRIPTION
Instead of Camelot key, in order to match Traktor.